### PR TITLE
Added Python packages for virtualenv initialization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+ansible==8.3.0
+ansible-core==2.15.3
+ansible-lint==6.17.2
+molecule==6.0.1
+molecule-plugins[vagrant]==23.5.0
+argcomplete==3.1.1
+yamllint==1.32.0


### PR DESCRIPTION
This is requiered for the Python 3.11.4 virtualenv project (current Fedora 37 Workstation main homelab machine) created with VSCode wizard (not Conda).

The requirements are:
- Ansible v8.3 (core v2.15.3).
- Ansible Lint v6.17.2.
- Molecule v6.0.1.
  - Molecule Vagrant plugin (from molecule-plugins suite v23.5.0).
- ArgComplete v3.1.1.
- YAML Lint v1.32.0.

Maybe there will be more dependencies or version changes.