### PR TITLE
Initializated tasks for Fedora hosts

### DIFF
--- a/roles/bootstrap.general/tasks/fedora.yml
+++ b/roles/bootstrap.general/tasks/fedora.yml
@@ -1,0 +1,2 @@
+---
+# general bootstrapping tasks file for Fedora hosts

--- a/roles/bootstrap.general/tasks/main.yml
+++ b/roles/bootstrap.general/tasks/main.yml
@@ -1,2 +1,6 @@
 ---
 # tasks file for bootstrap.general
+- name: FEDORA
+  ansible.builtin.import_tasks:
+    - fedora.yml
+  when: ansible_distribution == 'Fedora'


### PR DESCRIPTION
Created fedora.yml task file in bootstrap.general role, which is called in main.yml if the ansible_distribution fact value matches string "Fedora"