### PR TITLE
Added tag to skip Molecule idempotence test for DNF cache cleaning task

### DIFF
--- a/roles/bootstrap/tasks/fedora.yml
+++ b/roles/bootstrap/tasks/fedora.yml
@@ -2,6 +2,8 @@
 # bootstrapping tasks file for Fedora hosts
 - name: (FEDORA) Clean DNF cache
   ansible.builtin.command: /usr/bin/dnf clean all
+  tags:
+    - molecule-idempotence-notest
 
 - name: (FEDORA) DNF configuration
   ansible.builtin.lineinfile:


### PR DESCRIPTION
As described [here:](https://github.com/ansible/ansible/pull/31450#issuecomment-352889579)
DNF/YUM cache cleaning can't be cleaned in a idempotent way.

So I decided to use the command module to run a `dnf clean all`. But we run in a failed idempotency test in Molecule.

A workaround is to set the `molecule-idempotence-notest` tag in the task, as described [here](https://github.com/ansible/molecule/issues/816#issuecomment-573319053).
This forces Molecule to run the task on the first Converge execution, but not in the rest of tests.